### PR TITLE
Fix incorrect init if server has multiple worlds

### DIFF
--- a/src/main/java/cz/gennario/newrotatingheads/Main.java
+++ b/src/main/java/cz/gennario/newrotatingheads/Main.java
@@ -91,7 +91,7 @@ public final class Main extends JavaPlugin {
          *  HEADS LOADER
          * */
         File heads = createHeadsFolder();
-        loadHeads(heads);
+        getServer().getScheduler().runTask(this, () -> this.loadHeads(heads));
 
 
         new HeadInteraction().register();


### PR DESCRIPTION
Hello!
If server has multiple worlds and we have heads in these worlds there's continious spamming in console because not all worlds loads in time.
`load: POSTWORLD` in plugin.yml is also not fixing the problem
<pre>
[10:40:42] [Craft Scheduler Thread - 15 - RotatingHeads2/WARN]: [RotatingHeads2] Plugin RotatingHeads2 v1.0.3 generated an exception while executing task 74
java.lang.NullPointerException: Cannot invoke "org.bukkit.World.getPlayers()" because the return value of "org.bukkit.Location.getWorld()" is null
    at cz.gennario.newrotatingheads.system.HeadRunnable.run(HeadRunnable.java:20) ~[RotatingHeads2-1.0.3.jar:?]
    at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[patched_1.17.1.jar:git-Pufferfish-22]
    at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[patched_1.17.1.jar:git-Pufferfish-22]
    at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[patched_1.17.1.jar:git-Pufferfish-22]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
    at java.lang.Thread.run(Thread.java:833) ~[?:?]
</pre>