### PR TITLE
Update to support 1.20.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cz.gennario</groupId>
     <artifactId>RotatingHeads2</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>RotatingHeads2</name>
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -102,13 +102,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.3-R0.1-SNAPSHOT</version>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>5.1.0-SNAPSHOT</version>
+            <version>5.2.0-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -120,19 +120,19 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.0.1</version>
+            <version>24.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>dev.dejvokep</groupId>
@@ -143,23 +143,23 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>9.3.0</version>
+            <version>9.8.0</version>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.1</version>
+            <version>2.11.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
-            <version>0.12</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.nicecraftz</groupId>

--- a/src/main/java/cz/gennario/newrotatingheads/Command.java
+++ b/src/main/java/cz/gennario/newrotatingheads/Command.java
@@ -250,6 +250,8 @@ public class Command {
                             location = location.getBlock().getLocation();
                             location.add(0.5, 0, 0.5);
                         }
+                        heads.getYamlDocument().set("settings.invisible", true);
+                        heads.getYamlDocument().set("settings.arms", false);
 
                         heads.getYamlDocument().save();
                         heads.getYamlDocument().reload();

--- a/src/main/java/cz/gennario/newrotatingheads/utils/commands/CommandAPI.java
+++ b/src/main/java/cz/gennario/newrotatingheads/utils/commands/CommandAPI.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class CommandAPI {
@@ -298,7 +299,7 @@ public class CommandAPI {
                     }
                 }
 
-                return list;
+                return list.stream().filter(completion -> completion.startsWith(args[args.length-1])).collect(Collectors.toList());
             });
             Field field = SimplePluginManager.class.getDeclaredField("commandMap");
             field.setAccessible(true);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: RotatingHeads2
 author: Gennario
-version: 1.1.0
+version: 1.1.1
 main: cz.gennario.newrotatingheads.Main
 api-version: 1.13
 softdepend:


### PR DESCRIPTION
- When tab completing arguments, only arguments starting with what you have written will be completed. If, for example, you write "cre", instead of all arguments appearing as possible completions, only "create" will appear.
- Update HeadManager class to remove warnings on >1.18 versions
- Update dependencies

The plugin requires the latest version of ProtocolLib in order to work. I HAVE NOT TESTED ANY VERSION OTHER THAN 1.20.4