### PR TITLE
Concurrency fix

### DIFF
--- a/src/main/java/cz/gennario/newrotatingheads/Main.java
+++ b/src/main/java/cz/gennario/newrotatingheads/Main.java
@@ -122,7 +122,7 @@ public final class Main extends JavaPlugin {
 
 
         new HeadInteraction().register();
-        new HeadRunnable().runTaskTimer(this, 1, 1);
+        new HeadRunnable().runTaskTimerAsynchronously(this, 1, 1);
 
         pluginUpdater.sendLoadMessage();
 

--- a/src/main/java/cz/gennario/newrotatingheads/Main.java
+++ b/src/main/java/cz/gennario/newrotatingheads/Main.java
@@ -122,7 +122,7 @@ public final class Main extends JavaPlugin {
 
 
         new HeadInteraction().register();
-        new HeadRunnable().runTaskTimerAsynchronously(this, 1, 1);
+        new HeadRunnable().runTaskTimer(this, 1, 1);
 
         pluginUpdater.sendLoadMessage();
 

--- a/src/main/java/cz/gennario/newrotatingheads/rotatingengine/holograms/providers/PrivateHologramProvider.java
+++ b/src/main/java/cz/gennario/newrotatingheads/rotatingengine/holograms/providers/PrivateHologramProvider.java
@@ -11,19 +11,20 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Getter
 public class PrivateHologramProvider extends HologramExtender {
 
     private Map<Integer, PacketArmorStand> lines;
-    private List<Player> players;
+    private CopyOnWriteArrayList<Player> players;
     private double space;
     private boolean attachBottom;
 
     public PrivateHologramProvider(String name, RotatingHead rotatingHead) {
         super(name, rotatingHead);
         lines = new HashMap<>();
-        players = new ArrayList<>();
+        players = new CopyOnWriteArrayList<>();
     }
 
     @Override

--- a/src/main/java/cz/gennario/newrotatingheads/rotatingengine/holograms/providers/PrivateHologramProvider.java
+++ b/src/main/java/cz/gennario/newrotatingheads/rotatingengine/holograms/providers/PrivateHologramProvider.java
@@ -90,8 +90,9 @@ public class PrivateHologramProvider extends HologramExtender {
 
     @Override
     public void spawn(Player player) {
-        for (PacketArmorStand packetArmorStand : new ArrayList<>(lines.values())) {
-            if(!packetArmorStand.getName().equals("")) {
+        Map<Integer, PacketArmorStand> tempLines = new HashMap<>(lines);
+        for (PacketArmorStand packetArmorStand : new ArrayList<>(tempLines.values())) {
+            if(!packetArmorStand.getName().isEmpty()) {
                 packetArmorStand.spawn(player);
             }
         }
@@ -101,7 +102,8 @@ public class PrivateHologramProvider extends HologramExtender {
 
     @Override
     public void despawn(Player player) {
-        for (PacketArmorStand packetArmorStand : new ArrayList<>(lines.values())) {
+        Map<Integer, PacketArmorStand> tempLines = new HashMap<>(lines);
+        for (PacketArmorStand packetArmorStand : new ArrayList<>(tempLines.values())) {
             packetArmorStand.delete(player);
         }
 
@@ -110,7 +112,8 @@ public class PrivateHologramProvider extends HologramExtender {
 
     @Override
     public void refreshLines(Player player) {
-        for (PacketArmorStand packetArmorStand : new ArrayList<>(lines.values())) {
+        Map<Integer, PacketArmorStand> tempLines = new HashMap<>(lines);
+        for (PacketArmorStand packetArmorStand : new ArrayList<>(tempLines.values())) {
             packetArmorStand.updateName(player);
         }
     }

--- a/src/main/java/cz/gennario/newrotatingheads/system/RotatingHead.java
+++ b/src/main/java/cz/gennario/newrotatingheads/system/RotatingHead.java
@@ -30,6 +30,7 @@ import org.bukkit.util.EulerAngle;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 
 @Getter
@@ -78,7 +79,7 @@ public class RotatingHead {
     private PacketArmorStand packetArmorStand;
     private PacketEntity packetEntity;
     private EntityType entityType;
-    private List<Player> players;
+    private CopyOnWriteArrayList<Player> players;
     private List<ConditionValue> conditions = new ArrayList<>();
     private Replacement conditionsReplacement;
     private float yaw;
@@ -130,7 +131,7 @@ public class RotatingHead {
         this.packetArmorStand.setLocation(lastlocation);
         this.packetEntity.setLocation(lastlocation);
         this.animations = new ArrayList<>();
-        this.players = new ArrayList<>();
+        this.players = new CopyOnWriteArrayList<>();
 
         this.arms = false;
         this.invisible = true;
@@ -301,11 +302,11 @@ public class RotatingHead {
                 Math.toRadians(section.getInt("z")));
     }
 
-    private List<String> spawningCache = new ArrayList<>();
+    CopyOnWriteArrayList<String> spawningCache = new CopyOnWriteArrayList<>();
 
     public void spawn(Player player) {
         ArrayList<String> strings = new ArrayList<>(spawningCache);
-        if(strings.size() > 0) {
+        if(!strings.isEmpty()) {
             if (strings.contains(player.getName())) return;
         }
         spawningCache.add(player.getName());
@@ -573,7 +574,7 @@ public class RotatingHead {
         return this;
     }
 
-    public RotatingHead setPlayers(List<Player> players) {
+    public RotatingHead setPlayers(CopyOnWriteArrayList<Player> players) {
         this.players = players;
         return this;
     }


### PR DESCRIPTION
This caused errors such as two threads accesing one array at a time

```
[16:26:07] [Craft Scheduler Thread - 11 - RotatingHeads2/WARN]: [RotatingHeads2] Plugin RotatingHeads2 v1.2.0 generated an exception while executing task 35
java.lang.NegativeArraySizeException: -1
	at java.util.Arrays.copyOf(Arrays.java:3512) ~[?:?]
	at java.util.Arrays.copyOf(Arrays.java:3481) ~[?:?]
	at java.util.ArrayList.toArray(ArrayList.java:369) ~[?:?]
	at java.util.ArrayList.<init>(ArrayList.java:181) ~[?:?]
	at cz.gennario.newrotatingheads.system.RotatingHead.pingConditions(RotatingHead.java:437) ~[RotatingHeads2-1.2.0.jar:?]
	at cz.gennario.newrotatingheads.system.HeadRunnable.run(HeadRunnable.java:52) ~[RotatingHeads2-1.2.0.jar:?]
	at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftTask.run(CraftTask.java:101) ~[pufferfish-1.20.4.jar:git-Pufferfish-41]
	at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[pufferfish-1.20.4.jar:git-Pufferfish-41]
	at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[pufferfish-1.20.4.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```